### PR TITLE
Graceful node nextjs fix

### DIFF
--- a/src/loggly.tracker.js
+++ b/src/loggly.tracker.js
@@ -1,205 +1,211 @@
 // If not running in a browser then do nothing
-if (typeof window == "undefined") {
-  return;
-}
-
-(function (window, document) {
-    var LOGGLY_INPUT_PREFIX = 'http' + (('https:' === document.location.protocol ? 's' : '')) + '://',
-        LOGGLY_COLLECTOR_DOMAIN = 'logs-01.loggly.com',
-        LOGGLY_SESSION_KEY = 'logglytrackingsession',
-        LOGGLY_SESSION_KEY_LENGTH = LOGGLY_SESSION_KEY.length + 1,
-        LOGGLY_PROXY_DOMAIN = 'loggly';
+if (typeof window !== "undefined") {
+  (function (window, document) {
+    var LOGGLY_INPUT_PREFIX =
+        "http" + ("https:" === document.location.protocol ? "s" : "") + "://",
+      LOGGLY_COLLECTOR_DOMAIN = "logs-01.loggly.com",
+      LOGGLY_SESSION_KEY = "logglytrackingsession",
+      LOGGLY_SESSION_KEY_LENGTH = LOGGLY_SESSION_KEY.length + 1,
+      LOGGLY_PROXY_DOMAIN = "loggly";
 
     function uuid() {
-        // lifted from here -> http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
-        return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
-            var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
-            return v.toString(16);
-        });
+      // lifted from here -> http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
+      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (
+        c
+      ) {
+        var r = (Math.random() * 16) | 0,
+          v = c == "x" ? r : (r & 0x3) | 0x8;
+        return v.toString(16);
+      });
     }
 
     function LogglyTracker() {
-        this.key = false;
-        this.sendConsoleErrors = false;
-        this.tag = 'jslogger';
-        this.useDomainProxy = false;
-        this.useUtfEncoding = false;
+      this.key = false;
+      this.sendConsoleErrors = false;
+      this.tag = "jslogger";
+      this.useDomainProxy = false;
+      this.useUtfEncoding = false;
     }
 
     function setKey(tracker, key) {
-        tracker.key = key;
-        tracker.setSession();
-        setInputUrl(tracker);
+      tracker.key = key;
+      tracker.setSession();
+      setInputUrl(tracker);
     }
 
     function setTag(tracker, tag) {
-        tracker.tag = tag;
+      tracker.tag = tag;
     }
 
     function setDomainProxy(tracker, useDomainProxy) {
-        tracker.useDomainProxy = useDomainProxy;
-        //refresh inputUrl value
-        setInputUrl(tracker);
+      tracker.useDomainProxy = useDomainProxy;
+      //refresh inputUrl value
+      setInputUrl(tracker);
     }
 
-    function setUtfEncoding(tracker, useUtfEncoding){
-        tracker.useUtfEncoding = useUtfEncoding;
+    function setUtfEncoding(tracker, useUtfEncoding) {
+      tracker.useUtfEncoding = useUtfEncoding;
     }
 
     function setSendConsoleError(tracker, sendConsoleErrors) {
-        tracker.sendConsoleErrors = sendConsoleErrors;
+      tracker.sendConsoleErrors = sendConsoleErrors;
 
-        if (tracker.sendConsoleErrors === true) {
-            var _onerror = window.onerror;
-            //send console error messages to Loggly
-            window.onerror = function (msg, url, line, col, err){
-                tracker.push({
-                    category: 'BrowserJsException',
-                    exception: {
-                        message: msg,
-                        url: url,
-                        lineno: line,
-                        colno: col,
-                        stack: err ? err.stack : 'n/a',
-                    }
-                });
+      if (tracker.sendConsoleErrors === true) {
+        var _onerror = window.onerror;
+        //send console error messages to Loggly
+        window.onerror = function (msg, url, line, col, err) {
+          tracker.push({
+            category: "BrowserJsException",
+            exception: {
+              message: msg,
+              url: url,
+              lineno: line,
+              colno: col,
+              stack: err ? err.stack : "n/a",
+            },
+          });
 
-                if (_onerror && typeof _onerror === 'function') {
-                    _onerror.apply(window, arguments);
-                }
-            };
-        }
+          if (_onerror && typeof _onerror === "function") {
+            _onerror.apply(window, arguments);
+          }
+        };
+      }
     }
 
     function setInputUrl(tracker) {
-
-        if (tracker.useDomainProxy == true) {
-            tracker.inputUrl = LOGGLY_INPUT_PREFIX
-                + window.location.host
-                + '/'
-                + LOGGLY_PROXY_DOMAIN
-                + '/inputs/'
-                + tracker.key
-                + '/tag/'
-                + tracker.tag;
-        }
-        else {
-            tracker.inputUrl = LOGGLY_INPUT_PREFIX
-                + (tracker.logglyCollectorDomain || LOGGLY_COLLECTOR_DOMAIN)
-                + '/inputs/'
-                + tracker.key
-                + '/tag/'
-                + tracker.tag;
-        }
+      if (tracker.useDomainProxy == true) {
+        tracker.inputUrl =
+          LOGGLY_INPUT_PREFIX +
+          window.location.host +
+          "/" +
+          LOGGLY_PROXY_DOMAIN +
+          "/inputs/" +
+          tracker.key +
+          "/tag/" +
+          tracker.tag;
+      } else {
+        tracker.inputUrl =
+          LOGGLY_INPUT_PREFIX +
+          (tracker.logglyCollectorDomain || LOGGLY_COLLECTOR_DOMAIN) +
+          "/inputs/" +
+          tracker.key +
+          "/tag/" +
+          tracker.tag;
+      }
     }
 
     LogglyTracker.prototype = {
-        setSession: function (session_id) {
-            if (session_id) {
-                this.session_id = session_id;
-                this.setCookie(this.session_id);
-            } else if (!this.session_id) {
-                this.session_id = this.readCookie();
-                if (!this.session_id) {
-                    this.session_id = uuid();
-                    this.setCookie(this.session_id);
-                }
-            }
-        },
-        push: function (data) {
-            var type = typeof data;
-
-            if (!data || !(type === 'object' || type === 'string')) {
-                return;
-            }
-
-            var self = this;
-
-
-            if (type === 'string') {
-                data = {
-                    'text': data
-                };
-            } else {
-                if (data.logglyCollectorDomain) {
-                    self.logglyCollectorDomain = data.logglyCollectorDomain;
-                    return;
-                }
-
-                if (data.sendConsoleErrors !== undefined) {
-                    setSendConsoleError(self, data.sendConsoleErrors);
-                }
-
-                if (data.tag) {
-                    setTag(self, data.tag);
-                }
-
-                if (data.useUtfEncoding !== undefined) {
-                    setUtfEncoding(self, data.useUtfEncoding);
-                }
-
-                if (data.useDomainProxy) {
-                    setDomainProxy(self, data.useDomainProxy);
-                }
-
-                if (data.logglyKey) {
-                    setKey(self, data.logglyKey);
-                    return;
-                }
-
-                if (data.session_id) {
-                    self.setSession(data.session_id);
-                    return;
-                }
-            }
-
-            if (!self.key) {
-                return;
-            }
-
-            self.track(data);
-
-
-        },
-        track: function (data) {
-            // inject session id
-            data.sessionId = this.session_id;
-
-            try {
-                //creating an asynchronous XMLHttpRequest
-                var xmlHttp = new XMLHttpRequest();
-                xmlHttp.open('POST', this.inputUrl, true); //true for asynchronous request
-                if (tracker.useUtfEncoding === true) {
-                    xmlHttp.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
-                } else {
-                    xmlHttp.setRequestHeader('Content-Type', 'text/plain');
-                }
-                xmlHttp.send(JSON.stringify(data));
-
-            } catch (ex) {
-                if (window && window.console && typeof window.console.log === 'function') {
-                    console.log("Failed to log to loggly because of this exception:\n" + ex);
-                    console.log("Failed log data:", data);
-                }
-            }
-        },
-        /**
-            *  These cookie functions are not a global utilities.  It is for purpose of this tracker only
-        */
-        readCookie: function () {
-            var cookie = document.cookie,
-                i = cookie.indexOf(LOGGLY_SESSION_KEY);
-            if (i < 0) {
-                return false;
-            } else {
-                var end = cookie.indexOf(';', i + 1);
-                end = end < 0 ? cookie.length : end;
-                return cookie.slice(i + LOGGLY_SESSION_KEY_LENGTH, end);
-            }
-        },
-        setCookie: function (value) {
-            document.cookie = LOGGLY_SESSION_KEY + '=' + value;
+      setSession: function (session_id) {
+        if (session_id) {
+          this.session_id = session_id;
+          this.setCookie(this.session_id);
+        } else if (!this.session_id) {
+          this.session_id = this.readCookie();
+          if (!this.session_id) {
+            this.session_id = uuid();
+            this.setCookie(this.session_id);
+          }
         }
+      },
+      push: function (data) {
+        var type = typeof data;
+
+        if (!data || !(type === "object" || type === "string")) {
+          return;
+        }
+
+        var self = this;
+
+        if (type === "string") {
+          data = {
+            text: data,
+          };
+        } else {
+          if (data.logglyCollectorDomain) {
+            self.logglyCollectorDomain = data.logglyCollectorDomain;
+            return;
+          }
+
+          if (data.sendConsoleErrors !== undefined) {
+            setSendConsoleError(self, data.sendConsoleErrors);
+          }
+
+          if (data.tag) {
+            setTag(self, data.tag);
+          }
+
+          if (data.useUtfEncoding !== undefined) {
+            setUtfEncoding(self, data.useUtfEncoding);
+          }
+
+          if (data.useDomainProxy) {
+            setDomainProxy(self, data.useDomainProxy);
+          }
+
+          if (data.logglyKey) {
+            setKey(self, data.logglyKey);
+            return;
+          }
+
+          if (data.session_id) {
+            self.setSession(data.session_id);
+            return;
+          }
+        }
+
+        if (!self.key) {
+          return;
+        }
+
+        self.track(data);
+      },
+      track: function (data) {
+        // inject session id
+        data.sessionId = this.session_id;
+
+        try {
+          //creating an asynchronous XMLHttpRequest
+          var xmlHttp = new XMLHttpRequest();
+          xmlHttp.open("POST", this.inputUrl, true); //true for asynchronous request
+          if (tracker.useUtfEncoding === true) {
+            xmlHttp.setRequestHeader(
+              "Content-Type",
+              "text/plain; charset=utf-8"
+            );
+          } else {
+            xmlHttp.setRequestHeader("Content-Type", "text/plain");
+          }
+          xmlHttp.send(JSON.stringify(data));
+        } catch (ex) {
+          if (
+            window &&
+            window.console &&
+            typeof window.console.log === "function"
+          ) {
+            console.log(
+              "Failed to log to loggly because of this exception:\n" + ex
+            );
+            console.log("Failed log data:", data);
+          }
+        }
+      },
+      /**
+       *  These cookie functions are not a global utilities.  It is for purpose of this tracker only
+       */
+      readCookie: function () {
+        var cookie = document.cookie,
+          i = cookie.indexOf(LOGGLY_SESSION_KEY);
+        if (i < 0) {
+          return false;
+        } else {
+          var end = cookie.indexOf(";", i + 1);
+          end = end < 0 ? cookie.length : end;
+          return cookie.slice(i + LOGGLY_SESSION_KEY_LENGTH, end);
+        }
+      },
+      setCookie: function (value) {
+        document.cookie = LOGGLY_SESSION_KEY + "=" + value;
+      },
     };
 
     var existing = window._LTracker;
@@ -207,15 +213,15 @@ if (typeof window == "undefined") {
     var tracker = new LogglyTracker();
 
     if (existing && existing.length) {
-        var i = 0,
-            eLength = existing.length;
-        for (i = 0; i < eLength; i++) {
-            tracker.push(existing[i]);
-        }
+      var i = 0,
+        eLength = existing.length;
+      for (i = 0; i < eLength; i++) {
+        tracker.push(existing[i]);
+      }
     }
 
     window._LTracker = tracker; // default global tracker
 
-    window.LogglyTracker = LogglyTracker;   // if others want to instantiate more than one tracker
-
-})(window, document);
+    window.LogglyTracker = LogglyTracker; // if others want to instantiate more than one tracker
+  })(window, document);
+}

--- a/src/loggly.tracker.js
+++ b/src/loggly.tracker.js
@@ -1,227 +1,219 @@
 // If not running in a browser then do nothing
 if (typeof window !== "undefined") {
   (function (window, document) {
-    var LOGGLY_INPUT_PREFIX =
-        "http" + ("https:" === document.location.protocol ? "s" : "") + "://",
-      LOGGLY_COLLECTOR_DOMAIN = "logs-01.loggly.com",
-      LOGGLY_SESSION_KEY = "logglytrackingsession",
-      LOGGLY_SESSION_KEY_LENGTH = LOGGLY_SESSION_KEY.length + 1,
-      LOGGLY_PROXY_DOMAIN = "loggly";
+      var LOGGLY_INPUT_PREFIX = 'http' + (('https:' === document.location.protocol ? 's' : '')) + '://',
+          LOGGLY_COLLECTOR_DOMAIN = 'logs-01.loggly.com',
+          LOGGLY_SESSION_KEY = 'logglytrackingsession',
+          LOGGLY_SESSION_KEY_LENGTH = LOGGLY_SESSION_KEY.length + 1,
+          LOGGLY_PROXY_DOMAIN = 'loggly';
 
-    function uuid() {
-      // lifted from here -> http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
-      return "xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx".replace(/[xy]/g, function (
-        c
-      ) {
-        var r = (Math.random() * 16) | 0,
-          v = c == "x" ? r : (r & 0x3) | 0x8;
-        return v.toString(16);
-      });
-    }
-
-    function LogglyTracker() {
-      this.key = false;
-      this.sendConsoleErrors = false;
-      this.tag = "jslogger";
-      this.useDomainProxy = false;
-      this.useUtfEncoding = false;
-    }
-
-    function setKey(tracker, key) {
-      tracker.key = key;
-      tracker.setSession();
-      setInputUrl(tracker);
-    }
-
-    function setTag(tracker, tag) {
-      tracker.tag = tag;
-    }
-
-    function setDomainProxy(tracker, useDomainProxy) {
-      tracker.useDomainProxy = useDomainProxy;
-      //refresh inputUrl value
-      setInputUrl(tracker);
-    }
-
-    function setUtfEncoding(tracker, useUtfEncoding) {
-      tracker.useUtfEncoding = useUtfEncoding;
-    }
-
-    function setSendConsoleError(tracker, sendConsoleErrors) {
-      tracker.sendConsoleErrors = sendConsoleErrors;
-
-      if (tracker.sendConsoleErrors === true) {
-        var _onerror = window.onerror;
-        //send console error messages to Loggly
-        window.onerror = function (msg, url, line, col, err) {
-          tracker.push({
-            category: "BrowserJsException",
-            exception: {
-              message: msg,
-              url: url,
-              lineno: line,
-              colno: col,
-              stack: err ? err.stack : "n/a",
-            },
+      function uuid() {
+          // lifted from here -> http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
+          return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+              var r = Math.random() * 16 | 0, v = c == 'x' ? r : (r & 0x3 | 0x8);
+              return v.toString(16);
           });
-
-          if (_onerror && typeof _onerror === "function") {
-            _onerror.apply(window, arguments);
-          }
-        };
       }
-    }
 
-    function setInputUrl(tracker) {
-      if (tracker.useDomainProxy == true) {
-        tracker.inputUrl =
-          LOGGLY_INPUT_PREFIX +
-          window.location.host +
-          "/" +
-          LOGGLY_PROXY_DOMAIN +
-          "/inputs/" +
-          tracker.key +
-          "/tag/" +
-          tracker.tag;
-      } else {
-        tracker.inputUrl =
-          LOGGLY_INPUT_PREFIX +
-          (tracker.logglyCollectorDomain || LOGGLY_COLLECTOR_DOMAIN) +
-          "/inputs/" +
-          tracker.key +
-          "/tag/" +
-          tracker.tag;
+      function LogglyTracker() {
+          this.key = false;
+          this.sendConsoleErrors = false;
+          this.tag = 'jslogger';
+          this.useDomainProxy = false;
+          this.useUtfEncoding = false;
       }
-    }
 
-    LogglyTracker.prototype = {
-      setSession: function (session_id) {
-        if (session_id) {
-          this.session_id = session_id;
-          this.setCookie(this.session_id);
-        } else if (!this.session_id) {
-          this.session_id = this.readCookie();
-          if (!this.session_id) {
-            this.session_id = uuid();
-            this.setCookie(this.session_id);
-          }
-        }
-      },
-      push: function (data) {
-        var type = typeof data;
-
-        if (!data || !(type === "object" || type === "string")) {
-          return;
-        }
-
-        var self = this;
-
-        if (type === "string") {
-          data = {
-            text: data,
-          };
-        } else {
-          if (data.logglyCollectorDomain) {
-            self.logglyCollectorDomain = data.logglyCollectorDomain;
-            return;
-          }
-
-          if (data.sendConsoleErrors !== undefined) {
-            setSendConsoleError(self, data.sendConsoleErrors);
-          }
-
-          if (data.tag) {
-            setTag(self, data.tag);
-          }
-
-          if (data.useUtfEncoding !== undefined) {
-            setUtfEncoding(self, data.useUtfEncoding);
-          }
-
-          if (data.useDomainProxy) {
-            setDomainProxy(self, data.useDomainProxy);
-          }
-
-          if (data.logglyKey) {
-            setKey(self, data.logglyKey);
-            return;
-          }
-
-          if (data.session_id) {
-            self.setSession(data.session_id);
-            return;
-          }
-        }
-
-        if (!self.key) {
-          return;
-        }
-
-        self.track(data);
-      },
-      track: function (data) {
-        // inject session id
-        data.sessionId = this.session_id;
-
-        try {
-          //creating an asynchronous XMLHttpRequest
-          var xmlHttp = new XMLHttpRequest();
-          xmlHttp.open("POST", this.inputUrl, true); //true for asynchronous request
-          if (tracker.useUtfEncoding === true) {
-            xmlHttp.setRequestHeader(
-              "Content-Type",
-              "text/plain; charset=utf-8"
-            );
-          } else {
-            xmlHttp.setRequestHeader("Content-Type", "text/plain");
-          }
-          xmlHttp.send(JSON.stringify(data));
-        } catch (ex) {
-          if (
-            window &&
-            window.console &&
-            typeof window.console.log === "function"
-          ) {
-            console.log(
-              "Failed to log to loggly because of this exception:\n" + ex
-            );
-            console.log("Failed log data:", data);
-          }
-        }
-      },
-      /**
-       *  These cookie functions are not a global utilities.  It is for purpose of this tracker only
-       */
-      readCookie: function () {
-        var cookie = document.cookie,
-          i = cookie.indexOf(LOGGLY_SESSION_KEY);
-        if (i < 0) {
-          return false;
-        } else {
-          var end = cookie.indexOf(";", i + 1);
-          end = end < 0 ? cookie.length : end;
-          return cookie.slice(i + LOGGLY_SESSION_KEY_LENGTH, end);
-        }
-      },
-      setCookie: function (value) {
-        document.cookie = LOGGLY_SESSION_KEY + "=" + value;
-      },
-    };
-
-    var existing = window._LTracker;
-
-    var tracker = new LogglyTracker();
-
-    if (existing && existing.length) {
-      var i = 0,
-        eLength = existing.length;
-      for (i = 0; i < eLength; i++) {
-        tracker.push(existing[i]);
+      function setKey(tracker, key) {
+          tracker.key = key;
+          tracker.setSession();
+          setInputUrl(tracker);
       }
-    }
 
-    window._LTracker = tracker; // default global tracker
+      function setTag(tracker, tag) {
+          tracker.tag = tag;
+      }
 
-    window.LogglyTracker = LogglyTracker; // if others want to instantiate more than one tracker
+      function setDomainProxy(tracker, useDomainProxy) {
+          tracker.useDomainProxy = useDomainProxy;
+          //refresh inputUrl value
+          setInputUrl(tracker);
+      }
+
+      function setUtfEncoding(tracker, useUtfEncoding){
+          tracker.useUtfEncoding = useUtfEncoding;
+      }
+
+      function setSendConsoleError(tracker, sendConsoleErrors) {
+          tracker.sendConsoleErrors = sendConsoleErrors;
+
+          if (tracker.sendConsoleErrors === true) {
+              var _onerror = window.onerror;
+              //send console error messages to Loggly
+              window.onerror = function (msg, url, line, col, err){
+                  tracker.push({
+                      category: 'BrowserJsException',
+                      exception: {
+                          message: msg,
+                          url: url,
+                          lineno: line,
+                          colno: col,
+                          stack: err ? err.stack : 'n/a',
+                      }
+                  });
+
+                  if (_onerror && typeof _onerror === 'function') {
+                      _onerror.apply(window, arguments);
+                  }
+              };
+          }
+      }
+
+      function setInputUrl(tracker) {
+
+          if (tracker.useDomainProxy == true) {
+              tracker.inputUrl = LOGGLY_INPUT_PREFIX
+                  + window.location.host
+                  + '/'
+                  + LOGGLY_PROXY_DOMAIN
+                  + '/inputs/'
+                  + tracker.key
+                  + '/tag/'
+                  + tracker.tag;
+          }
+          else {
+              tracker.inputUrl = LOGGLY_INPUT_PREFIX
+                  + (tracker.logglyCollectorDomain || LOGGLY_COLLECTOR_DOMAIN)
+                  + '/inputs/'
+                  + tracker.key
+                  + '/tag/'
+                  + tracker.tag;
+          }
+      }
+
+      LogglyTracker.prototype = {
+          setSession: function (session_id) {
+              if (session_id) {
+                  this.session_id = session_id;
+                  this.setCookie(this.session_id);
+              } else if (!this.session_id) {
+                  this.session_id = this.readCookie();
+                  if (!this.session_id) {
+                      this.session_id = uuid();
+                      this.setCookie(this.session_id);
+                  }
+              }
+          },
+          push: function (data) {
+              var type = typeof data;
+
+              if (!data || !(type === 'object' || type === 'string')) {
+                  return;
+              }
+
+              var self = this;
+
+
+              if (type === 'string') {
+                  data = {
+                      'text': data
+                  };
+              } else {
+                  if (data.logglyCollectorDomain) {
+                      self.logglyCollectorDomain = data.logglyCollectorDomain;
+                      return;
+                  }
+
+                  if (data.sendConsoleErrors !== undefined) {
+                      setSendConsoleError(self, data.sendConsoleErrors);
+                  }
+
+                  if (data.tag) {
+                      setTag(self, data.tag);
+                  }
+
+                  if (data.useUtfEncoding !== undefined) {
+                      setUtfEncoding(self, data.useUtfEncoding);
+                  }
+
+                  if (data.useDomainProxy) {
+                      setDomainProxy(self, data.useDomainProxy);
+                  }
+
+                  if (data.logglyKey) {
+                      setKey(self, data.logglyKey);
+                      return;
+                  }
+
+                  if (data.session_id) {
+                      self.setSession(data.session_id);
+                      return;
+                  }
+              }
+
+              if (!self.key) {
+                  return;
+              }
+
+              self.track(data);
+
+
+          },
+          track: function (data) {
+              // inject session id
+              data.sessionId = this.session_id;
+
+              try {
+                  //creating an asynchronous XMLHttpRequest
+                  var xmlHttp = new XMLHttpRequest();
+                  xmlHttp.open('POST', this.inputUrl, true); //true for asynchronous request
+                  if (tracker.useUtfEncoding === true) {
+                      xmlHttp.setRequestHeader('Content-Type', 'text/plain; charset=utf-8');
+                  } else {
+                      xmlHttp.setRequestHeader('Content-Type', 'text/plain');
+                  }
+                  xmlHttp.send(JSON.stringify(data));
+
+              } catch (ex) {
+                  if (window && window.console && typeof window.console.log === 'function') {
+                      console.log("Failed to log to loggly because of this exception:\n" + ex);
+                      console.log("Failed log data:", data);
+                  }
+              }
+          },
+          /**
+              *  These cookie functions are not a global utilities.  It is for purpose of this tracker only
+          */
+          readCookie: function () {
+              var cookie = document.cookie,
+                  i = cookie.indexOf(LOGGLY_SESSION_KEY);
+              if (i < 0) {
+                  return false;
+              } else {
+                  var end = cookie.indexOf(';', i + 1);
+                  end = end < 0 ? cookie.length : end;
+                  return cookie.slice(i + LOGGLY_SESSION_KEY_LENGTH, end);
+              }
+          },
+          setCookie: function (value) {
+              document.cookie = LOGGLY_SESSION_KEY + '=' + value;
+          }
+      };
+
+      var existing = window._LTracker;
+
+      var tracker = new LogglyTracker();
+
+      if (existing && existing.length) {
+          var i = 0,
+              eLength = existing.length;
+          for (i = 0; i < eLength; i++) {
+              tracker.push(existing[i]);
+          }
+      }
+
+      window._LTracker = tracker; // default global tracker
+
+      window.LogglyTracker = LogglyTracker;   // if others want to instantiate more than one tracker
+
   })(window, document);
 }


### PR DESCRIPTION
See main PR here: https://github.com/ahmdigital/ahm-sales/pull/5384

Background on this repo:
- This repo is a fork of [this](https://github.com/loggly/loggly-jslogger), to support some changes to the repo to enable it to work with NextJS
- These changes live in a [branch of this repo](https://github.com/ahmdigital/loggly-jslogger/compare/master...ahmdigital:loggly-jslogger:graceful-node?expand=1), which is [used](https://github.com/ahmdigital/ahm-logger-frontend/blob/8cfb0a074659baf24a43223082b9dfdb241fb254/package.json#L26) by ahm-logger-frontend, which is used by sales and members
- These changes were never merged into our fork. A pull request was created, but it was [mistakenly created](https://github.com/loggly/loggly-jslogger/pull/84) against the original repo rather than our fork
- Yes, sales and members prod both depend on this unmerged branch

This change is to fix this functionality for NextJS. The original changes seem to actually break NextJS, since they do a return outside of a function which is an unrecoverable SyntaxError. The error we saw was `Uncaught SyntaxError: Illegal return statement`
The fix is to wrap the IIFE in an if-statement instead.

### Release notes
 - To ensure this PR is backwards compatible, PR will need to be tested on 2 separate devboxes. One running on NextJS and current implementation. 
 - Once PR has been verified, will merge this branch into `graceful-node`.   